### PR TITLE
chore(logger.py): clean up logging

### DIFF
--- a/logger.py
+++ b/logger.py
@@ -1,174 +1,15 @@
 #!/usr/bin/env python
 
-from pymongo import MongoClient, errors
-from bson import ObjectId
+from mongouploader import MongoManager
 from datetime import datetime, timezone
 import os
 import time
 import json
 
+DELAY = 0.2
+LOG_FILE_PATH = "/odtp/odtp-logs/log.txt"
+LOG_END_STRING = "--- ODTP COMPONENT ENDING ---"
 
-class MongoManager:
-    def __init__(self, mongodbUrl, db_name):
-        self.client = MongoClient(mongodbUrl)
-        self.db = self.client[db_name]
-    
-    def add_logs(self, log_data_list):
-        logs_collection = self.db["logs"]
-
-        log_ids = logs_collection.insert_many(log_data_list).inserted_ids
-
-        return log_ids
-    
-    def add_output(self, step_id, output_data):
-        output_collection = self.db["outputs"]
-        output_data["stepRef"] = step_id
-
-        # TODO: Make its own function. Taking out user_id
-        #output_data["access_control"]["authorized_users"] = user_id
-
-        output_id = output_collection.insert_one(output_data).inserted_id
-
-        # Update steps with execution reference
-        self.db.steps.update_one(
-            {"_id": ObjectId(step_id)},  # Specify the document to update
-            {"$set": {"output": output_id}}  # Use $set to replace the value of a field
-        )
-
-        return output_id
-    
-
-    def append_log(self, step_id, log_data):
-        steps_collection = self.db["steps"]
-        steps_collection.update_one(
-            {"_id": ObjectId(step_id)},
-            {"$push": {"logs": log_data}}
-        )
-    
-    def append_logs(self, step_id, log_data_list):
-        steps_collection = self.db["steps"]
-        steps_collection.update_one(
-            {"_id": ObjectId(step_id)},
-            {"$push": {"logs": {"$each": log_data_list}}}
-        )
-    
-    def update_result(self, result_id, output_id):
-        results_collection = self.db["results"]
-        results_collection.update_one(
-            {"_id": ObjectId(result_id)},
-            {"$push": {"output": output_id}}
-        )
-
-        results_collection.update_one(
-            {"_id": ObjectId(result_id)},
-            {"$set": {"updated_at": datetime.now(timezone.utc)}}
-        )
-
-    def update_timestamp(self, step_id, field):
-        steps_collection = self.db["steps"]
-        steps_collection.update_one(
-            {"_id": ObjectId(step_id)},
-            {"$set": {field: datetime.now(timezone.utc)}}
-        )
-
-    def get_all_collections_as_dict(self):
-            """
-            Retrieve all documents in all collections as a dictionary.
-            """
-            all_data = {}
-            for collection_name in self.db.list_collection_names():
-                cursor = self.db[collection_name].find()
-                all_data[collection_name] = [doc for doc in cursor]
-            
-            return all_data
-
-    def get_all_collections_as_json_string(self):
-        """
-        Retrieve all documents in all collections as a JSON-formatted string.
-        """
-        all_data = self.get_all_collections_as_dict()
-        return json.dumps(all_data, indent=2, default=str)  # default=str to handle datetime and ObjectId
-
-
-    def print_all_collections_as_json(self):
-        """
-        Print all documents in all collections in JSON format.
-        """
-        for collection_name in self.db.list_collection_names():
-            print(f"Collection: {collection_name}")
-            cursor = self.db[collection_name].find()
-            for doc in cursor:
-                print(json.dumps(doc, indent=2, default=str))  # default=str is added to handle datetime and ObjectId
-            print("-" * 50)  # separator line between collections
-
-
-    def export_all_collections_as_json(self, filename):
-        """
-        Save all documents in all collections as a JSON file.
-        """
-        all_data = self.get_all_collections_as_dict()
-        with open(filename, 'w') as json_file:
-            json.dump(all_data, json_file, indent=2, default=str)  # default=str to handle datetime and ObjectId
-
-
-    ######################################
-    # USER METHOD
-
-    def get_all_users(self):
-        cursor = self.db.users.find({})
-
-        users = []
-        for doc in cursor:
-            doc["_id"] = str(doc["_id"])  # Convert ObjectId to string
-            users.append(doc)
-
-        return users
-    
-    def get_digital_twins_by_user_id(self, user_id_str):
-        # Convert user_id string to ObjectId
-        user_id = ObjectId(user_id_str)
-        
-        # Fetch digital twins by user_id
-        cursor = self.db.digitalTwins.find({"userRef": user_id}, {"_id": 1, "userRef": 1, "executions[0].timestamp": 1, "executions[0].timestamp": 1})
-        
-        digital_twins = []
-        for doc in cursor:
-            doc["_id"] = str(doc["_id"])  # Convert ObjectId to string for pandas compatibility
-            digital_twins.append(doc)
-            
-        return digital_twins
-    
-    def print_logs_by_indices(self, twin_index, execution_index, step_index):
-        # Skip to the digital twin specified by the given index and retrieve it
-        digital_twin = self.db.digitalTwins.find().sort("_id", 1).skip(twin_index).limit(1).next()
-
-        try:
-            # Navigate to the logs using the given execution index
-            logs = digital_twin["executions"][execution_index]["steps"][step_index]["logs"]
-        except (IndexError, KeyError):
-            print(f"No logs found for execution {execution_index} of digital twin {twin_index}.")
-
-        return logs
-
-    ######################################
-    # Closing & Deleting
-    ######################################
-
-    def close(self):
-        self.client.close()
-
-    def deleteAll(self):
-        # Connect to your database. Replace 'mydatabase' with your database name.
-        db_odtp = self.db
-
-        # Get a list of all collections in the database
-        collections = db_odtp.list_collection_names()
-        # Drop each collection
-        for collection in collections:
-            db_odtp.drop_collection(collection)
-
-
-########### LogReader 
 class LogReader:
     def __init__(self, log_file):
         self.log_file = log_file
@@ -190,20 +31,14 @@ class LogReader:
         return lines
 
 
-############ Main Method
-# This method will push the log to an existing execution step
-
-def main(delay=2):
-    ### Create Entry
-    MONGO_URL = os.getenv("ODTP_MONGO_SERVER")
+def main():
     step_id = os.getenv("ODTP_STEP_ID")
-    db_name = "odtp"
+    try:
+        dbManager = MongoManager()
+    except Exception as e:
+        sys.exit(f"Mongo manager failed to load: Exception {e} occurred")
 
-    dbManager = MongoManager(MONGO_URL, db_name)
-    dbManager.update_timestamp(step_id, "start_timestamp")
-    dbManager.close()
-    
-    log_reader = LogReader('/odtp/odtp-logs/log.txt')
+    log_reader = LogReader(LOG_FILE_PATH)
 
     # Active until it finds "--- ODTP COMPONENT ENDING ---"
     ending_detected = False
@@ -219,25 +54,16 @@ def main(delay=2):
 
             newLogList.append(newLogEntry)
 
-
-        dbManager = MongoManager(MONGO_URL, db_name)
-        # _ = dbManager.append_logs(step_id, newLogList)
         _ = dbManager.add_logs(newLogList)
         dbManager.close()
 
-        time.sleep(0.2)
+        time.sleep(DELAY)
 
         # TODO: Improve this
-        if log == "--- ODTP COMPONENT ENDING ---":
-            dbManager = MongoManager(MONGO_URL, db_name)
-            dbManager.update_timestamp(step_id, "end_timestamp")
-            dbManager.close()
-
+        if log == LOG_END_STRING:
             ending_detected = True
-
-        #time.sleep(delay)
 
 
 if __name__ == '__main__':
-    main(delay=0.5)
+    main()
 

--- a/logger.py
+++ b/logger.py
@@ -3,6 +3,7 @@
 from mongouploader import MongoManager
 from datetime import datetime, timezone
 import os
+import sys
 import time
 
 
@@ -54,7 +55,8 @@ def main():
 
             newLogList.append(newLogEntry)
 
-        _ = dbManager.add_logs(newLogList)
+        if newLogList:    
+            _ = dbManager.add_logs(newLogList)
         dbManager.close()
 
         time.sleep(DELAY)

--- a/logger.py
+++ b/logger.py
@@ -62,7 +62,7 @@ def main():
                 "logstring": "\n".join(log_page)                
             }
             print(f"add log_page_entry to db: {log_page_entry}")
-            _ = dbManager.add_logs(log_page_entry)
+            _ = dbManager.add_log_page(log_page_entry)
             print("empty log_page")
             log_page = []
 
@@ -70,17 +70,8 @@ def main():
 
         # TODO: Improve this
         if log == LOG_END_STRING:
-            print("ending was detected")
-            print(f"length log_page >= 10: {len(log_page)}")
-            log_page_entry = {
-                "stepRef": step_id,
-                "timestamp": datetime.now(timezone.utc),
-                "logstring": "\n".join(log_page)                
-            }
-            print(f"add log_page_entry to db: {log_page_entry}")
-            _ = dbManager.add_logs(log_page_entry)
-            print("empty log_page")
-            log_page = []            
+            print("ending was detected: add last log page to db")
+            _ = dbManager.add_log_page(log_page)          
             ending_detected = True
             break
 

--- a/logger.py
+++ b/logger.py
@@ -40,6 +40,7 @@ def main():
         sys.exit(f"Mongo manager failed to load: Exception {e} occurred")
 
     log_reader = LogReader(LOG_FILE_PATH)
+    log_page = []
 
     # Active until it finds "--- ODTP COMPONENT ENDING ---"
     ending_detected = False
@@ -47,16 +48,18 @@ def main():
         logs = log_reader.read_from_last_position()
         
         newLogList = []
+
         for log in logs:
-            newLogEntry= {
-            "stepRef": step_id,
-            "timestamp": datetime.now(timezone.utc),
-            "logstring": log}
+            log_page.append(log)
 
-            newLogList.append(newLogEntry)
-
-        if newLogList:    
-            _ = dbManager.add_logs(newLogList)
+        if len(log_page) >= 10:
+            log_page_entry = {
+                "stepRef": step_id,
+                "timestamp": datetime.now(timezone.utc),
+                "logstring": "\n".join(log_page)                
+            }
+            _ = dbManager.add_logs(log_page_entry)
+            log_page = []
 
         time.sleep(DELAY)
 

--- a/logger.py
+++ b/logger.py
@@ -57,13 +57,15 @@ def main():
 
         if newLogList:    
             _ = dbManager.add_logs(newLogList)
-        dbManager.close()
 
         time.sleep(DELAY)
 
         # TODO: Improve this
         if log == LOG_END_STRING:
             ending_detected = True
+            break
+
+    dbManager.close()        
 
 
 if __name__ == '__main__':

--- a/logger.py
+++ b/logger.py
@@ -4,7 +4,7 @@ from mongouploader import MongoManager
 from datetime import datetime, timezone
 import os
 import time
-import json
+
 
 DELAY = 0.2
 LOG_FILE_PATH = "/odtp/odtp-logs/log.txt"

--- a/logger.py
+++ b/logger.py
@@ -45,26 +45,42 @@ def main():
     # Active until it finds "--- ODTP COMPONENT ENDING ---"
     ending_detected = False
     while ending_detected == False:
-        logs = log_reader.read_from_last_position()
-        
-        newLogList = []
+        print("-------- new loop")
+        log_reading_batch = log_reader.read_from_last_position()
+        print(f"log_reading_batch: {log_reading_batch}")
 
-        for log in logs:
+        for log in log_reading_batch:
             log_page.append(log)
 
+        print(f"log_page: {log_page}")    
+
         if len(log_page) >= 10:
+            print(f"length log_page >= 10: {len(log_page)}")
             log_page_entry = {
                 "stepRef": step_id,
                 "timestamp": datetime.now(timezone.utc),
                 "logstring": "\n".join(log_page)                
             }
+            print(f"add log_page_entry to db: {log_page_entry}")
             _ = dbManager.add_logs(log_page_entry)
+            print("empty log_page")
             log_page = []
 
         time.sleep(DELAY)
 
         # TODO: Improve this
         if log == LOG_END_STRING:
+            print("ending was detected")
+            print(f"length log_page >= 10: {len(log_page)}")
+            log_page_entry = {
+                "stepRef": step_id,
+                "timestamp": datetime.now(timezone.utc),
+                "logstring": "\n".join(log_page)                
+            }
+            print(f"add log_page_entry to db: {log_page_entry}")
+            _ = dbManager.add_logs(log_page_entry)
+            print("empty log_page")
+            log_page = []            
             ending_detected = True
             break
 

--- a/logger.py
+++ b/logger.py
@@ -56,13 +56,7 @@ def main():
 
         if len(log_page) >= 10:
             print(f"length log_page >= 10: {len(log_page)}")
-            log_page_entry = {
-                "stepRef": step_id,
-                "timestamp": datetime.now(timezone.utc),
-                "logstring": "\n".join(log_page)                
-            }
-            print(f"add log_page_entry to db: {log_page_entry}")
-            _ = dbManager.add_log_page(log_page_entry)
+            _ = dbManager.add_log_page(log_page)
             print("empty log_page")
             log_page = []
 

--- a/mongouploader.py
+++ b/mongouploader.py
@@ -10,6 +10,7 @@ ODTP_MONGO_DB = "odtp"
 STEPS_COLLECTION = "steps"
 RESULTS_COLLECTION = "results"
 OUTPUTS_COLLECTION = "outputs"
+LOGS_COLLECTION = "logs"
 
 
 class MongoManager(object):
@@ -18,13 +19,22 @@ class MongoManager(object):
         self.client = MongoClient(mongodb_url)
         self.db = self.client[ODTP_MONGO_DB]
         self.step_id = os.getenv("ODTP_STEP_ID")
+        self.logs = self.db[LOGS_COLLECTION]
 
-    def add_logs(self, log_data_list):
-        logs_collection = self.db["logs"]
+    def add_log_page(self, log_page):
+        if not log_page:
+            print(f"log_page empty not entered into db:{log_page}")
+            return
+        log_page_entry = {
+            "stepRef": self.step_id,
+            "timestamp": datetime.now(timezone.utc),
+            "logstring": "\n".join(log_page)                
+        }
+        print(f"add log_page_entry to db: {log_page_entry}")        
+        log_id = self.logs.insert_one(log_page_entry).inserted_id
+        print(f"successfull db entry {log_id}")
 
-        log_ids = logs_collection.insert_many(log_data_list).inserted_ids
-
-        return log_ids       
+        return log_id       
 
     def add_output(self, step_id, output_data):
         output_collection = self.db[OUTPUTS_COLLECTION]

--- a/mongouploader.py
+++ b/mongouploader.py
@@ -24,20 +24,7 @@ class MongoManager(object):
 
         log_ids = logs_collection.insert_many(log_data_list).inserted_ids
 
-        return log_ids
-
-    def add_logs_to_mongodb(self, log_page):
-        log_entry = self.format_log_entry(log_page)
-        log_ids = self.logs_collection.insert_many(log_entry).inserted_ids
-        return log_ids
-
-    def format_log_entry(self, log_page):
-        log_entry = {
-            "stepRef": self.step_id,
-            "timestamp": datetime.now(timezone.utc),
-            "logstring": log_page,
-        }
-        return log_entry        
+        return log_ids       
 
     def add_output(self, step_id, output_data):
         output_collection = self.db[OUTPUTS_COLLECTION]

--- a/mongouploader.py
+++ b/mongouploader.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+
+from pymongo import MongoClient
+from bson import ObjectId
+from datetime import datetime, timezone
+import os
+
+
+ODTP_MONGO_DB = "odtp"
+STEPS_COLLECTION = "steps"
+RESULTS_COLLECTION = "results"
+OUTPUTS_COLLECTION = "outputs"
+
+
+class MongoManager(object):
+    def __init__(self):
+        mongodb_url = os.getenv("ODTP_MONGO_SERVER")
+        self.client = MongoClient(mongodb_url)
+        self.db = self.client[ODTP_MONGO_DB]
+        self.step_id = os.getenv("ODTP_STEP_ID")
+
+    def add_logs(self, log_data_list):
+        logs_collection = self.db["logs"]
+
+        log_ids = logs_collection.insert_many(log_data_list).inserted_ids
+
+        return log_ids
+
+    def add_logs_to_mongodb(self, log_page):
+        log_entry = self.format_log_entry(log_page)
+        log_ids = self.logs_collection.insert_many(log_entry).inserted_ids
+        return log_ids
+
+    def format_log_entry(self, log_page):
+        log_entry = {
+            "stepRef": self.step_id,
+            "timestamp": datetime.now(timezone.utc),
+            "logstring": log_page,
+        }
+        return log_entry        
+
+    def add_output(self, step_id, output_data):
+        output_collection = self.db[OUTPUTS_COLLECTION]
+        output_data["stepRef"] = step_id
+
+        # TODO: Make its own function. Taking out user_id
+        #output_data["access_control"]["authorized_users"] = user_id
+
+        output_id = output_collection.insert_one(output_data).inserted_id
+
+        # Update steps with execution reference
+        self.db.steps.update_one(
+            {"_id": ObjectId(step_id)},  # Specify the document to update
+            {"$set": {"output": output_id}}  # Use $set to replace the value of a field
+        )
+
+        return output_id
+
+    def update_result(self, result_id, output_id):
+        results_collection = self.db[RESULTS_COLLECTION]
+        results_collection.update_one(
+            {"_id": ObjectId(result_id)},
+            {"$push": {"output": output_id}}
+        )
+
+        results_collection.update_one(
+            {"_id": ObjectId(result_id)},
+            {"$set": {"updated_at": datetime.now(timezone.utc)}}
+        )
+
+    def close(self):
+        self.client.close()

--- a/mongouploader.py
+++ b/mongouploader.py
@@ -23,16 +23,13 @@ class MongoManager(object):
 
     def add_log_page(self, log_page):
         if not log_page:
-            print(f"log_page empty not entered into db:{log_page}")
             return
         log_page_entry = {
             "stepRef": self.step_id,
             "timestamp": datetime.now(timezone.utc),
             "logstring": "\n".join(log_page)                
-        }
-        print(f"add log_page_entry to db: {log_page_entry}")        
+        }       
         log_id = self.logs.insert_one(log_page_entry).inserted_id
-        print(f"successfull db entry {log_id}")
 
         return log_id       
 

--- a/odtp-app.sh
+++ b/odtp-app.sh
@@ -48,6 +48,8 @@ function transfer_input_to_output() {
         odtp::print_info "copy inputs to the output directory"
         cp -r /odtp/odtp-input/* /odtp/odtp-output
 
+        exit_code="$?"
+
         if [ "$exit_code" -ne 0 ]; then
             odtp::print_error \
                 "Coping input to output failed with exit code '$exit_code'."
@@ -64,6 +66,8 @@ function compress_output () {
     odtp::print_info "move to output directory"
     cd /odtp/odtp-output
 
+    exit_code="$?"
+
     if [ "$exit_code" -ne 0 ]; then
         odtp::print_error \
             "'cd /odtp/odtp-output' failed with exit code '$exit_code'."
@@ -72,6 +76,8 @@ function compress_output () {
     odtp::print_info "zip output directory"
     zip -rq ../odtp-output.zip ./*
 
+    exit_code="$?"
+
     if [ "$exit_code" -ne 0 ]; then
         odtp::print_error \
             "'zip -rq ../odtp-output.zip ./*' failed with exit code '$exit_code'."
@@ -79,6 +85,8 @@ function compress_output () {
      
     odtp::print_info "move zipped output file"
     mv ../odtp-output.zip odtp-output.zip
+
+    exit_code="$?"
 
     if [ "$exit_code" -ne 0 ]; then
         odtp::print_error \
@@ -104,6 +112,8 @@ function compress_workdir () {
         odtp::print_info "zip workdir into a snapshot"
         zip -rq ../odtp-snapshot.zip ./*
 
+        exit_code="$?"
+
         if [ "$exit_code" -ne 0 ]; then
             odtp::print_error \
                 "'zip -rq ../odtp-snapshot.zip ./*' failed with exit code '$exit_code'."
@@ -111,6 +121,8 @@ function compress_workdir () {
       
         odtp::print_info "Move snapshot one directory up"
         mv ../odtp-snapshot.zip odtp-snapshot.zip
+
+        exit_code="$?"
 
         if [ "$exit_code" -ne 0 ]; then
             odtp::print_error \
@@ -128,6 +140,8 @@ function upload_snapshot () {
         odtp::print_info "Uploading the outputs to S3"
         python3 /odtp/odtp-component-client/s3uploader.py 2>&1 | tee /odtp/odtp-logs/odtpS3UploadedDebugging.txt
 
+        exit_code="$?"
+
         if [ "$exit_code" -ne 0 ]; then
             odtp::print_error \
                 "'python3 /odtp/odtp-component-client/s3uploader.py 2>&1 | tee /odtp/odtp-logs/odtpS3UploadedDebugging.txt' failed with '$exit_code'."
@@ -144,6 +158,8 @@ function move_logs_to_output () {
 
     odtp::print_info "Copying the logs to the output directory"
     cp /odtp/odtp-logs/log.txt /odtp/odtp-output/log.txt
+
+    exit_code="$?"
 
     if [ "$exit_code" -ne 0 ]; then
         odtp::print_error \

--- a/parameters.py
+++ b/parameters.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 import yaml
 import os
 import re

--- a/parameters.py
+++ b/parameters.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
-import yaml
 import os
 import re
 import sys
-import logging
 
 
 def __readTemplate(templatefile):

--- a/s3uploader.py
+++ b/s3uploader.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 from datetime import datetime, timezone
 import os
-import time
 import logging
 import boto3
 import sys

--- a/s3uploader.py
+++ b/s3uploader.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 from datetime import datetime, timezone
 import os
 import time
@@ -6,7 +7,7 @@ import boto3
 import sys
 
 sys.path.append('/odtp/odtp-app/odtp-client')
-from logger import MongoManager
+from mongouploader import MongoManager
 
 ### This method needs to create a new entry in snapshots MONGODB and upload the output.zip to s3. 
 ### At this moment the structure is not that important as to make things works together. 
@@ -66,10 +67,10 @@ def main():
     SECRET_KEY = os.getenv("ODTP_SECRET_KEY")
     STEP_ID = os.getenv("ODTP_STEP_ID")
     odtpS3 = s3Manager(S3_SERVER, BUCKET_NAME, ACCESS_KEY, SECRET_KEY)
-
-    MONGO_URL = os.getenv("ODTP_MONGO_SERVER")
-    db_name = "odtp"
-    dbManager = MongoManager(MONGO_URL, db_name)
+    try:
+        dbManager = MongoManager()
+    except Exception as e:
+        sys.exit(f"Mongo manager failed to load: Exception {e} occurred")
 
     USER_ID = os.getenv("ODTP_USER_ID")
     ODTP_OUTPUT_PATH = f"odtp/{STEP_ID}"

--- a/src/shell/log.sh
+++ b/src/shell/log.sh
@@ -43,7 +43,7 @@ function odtp::internal::print() {
   local msg
   msg=$(printf '%b\n' "$@")
   msg="${msg//$'\n'/$'\n'   }"
-  echo $flags -e "⚙️   $header$msg"
+  echo $flags -e "->   $header$msg"
 }
 
 # Trace functionality.


### PR DESCRIPTION
This PR does the following:
- seperates `logger.py` from `mongouploader.py`: since the second script is also called from `s3uploader.py`: it seems cleaner to have different scripts for the 2 purposes: `logger.py` reads the log output and collects it into pages while `mongouploader.py` uploads these pages to the mongodb
- the script `odtp-app.sh` had errors as the bash return code had not been written into the variable `exit_code`
- there was a special character as marker for log outputs: it has been replaced by `->`