### PR TITLE
Chore/remove log copying

### DIFF
--- a/odtp-app.sh
+++ b/odtp-app.sh
@@ -154,22 +154,6 @@ function upload_snapshot () {
 
 }
 
-function move_logs_to_output () {
-
-    odtp::print_info "Copying the logs to the output directory"
-    cp /odtp/odtp-logs/log.txt /odtp/odtp-output/log.txt
-
-    exit_code="$?"
-
-    if [ "$exit_code" -ne 0 ]; then
-        odtp::print_error \
-            "copying log files to output failed with '$exit_code'."
-    fi
-
-    return 0
-
-}
-
 function main() {
     odtp::print_info "Starting odtp component."
 
@@ -193,7 +177,6 @@ function main() {
     compress_output
     compress_workdir
     upload_snapshot
-    move_logs_to_output
 }
 
 main "$@"

--- a/scripts/component-update.sh
+++ b/scripts/component-update.sh
@@ -3,7 +3,7 @@
 # GIT_PATH should be an empty directory
 GIT_PATH=/Users/smaennel/odtp/git
 GIT_ORG=odtp-org
-BRANCH=chore/cleanup-logger
+BRANCH=chore/main
 
 # Function to update COMPONENT for TAG
 update_client() {


### PR DESCRIPTION
This PR remove the step of copying the log files to the output directory: this is no longer needed, as the logs are available as a volume on the project path.